### PR TITLE
Catch trailing slash

### DIFF
--- a/gitlab-scoped-labels.js
+++ b/gitlab-scoped-labels.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name     GitLab scoped labels (view only)
-// @version  12
+// @version  13
 // @grant    none
 // @include  https://git.octocat.lab/*
 // @license  GPL-3.0 License; https://www.gnu.org/licenses/gpl-3.0.txt
@@ -25,7 +25,7 @@ if(window.location.pathname.match(/.*\/boards/)) { // boards
   }
   const observer = new MutationObserver(callback)
   observer.observe(document, { childList: true, subtree: true })
-} else if(window.location.pathname.match(/.*\/issues$/)) { // issues list
+} else if(window.location.pathname.match(/.*\/issues\/?$/)) { // issues list
   const callback = function(mutations, observer) {
     for(const mutation of mutations) {
       for(const addedElement of mutation.addedNodes) {


### PR DESCRIPTION
Sometimes in our setup you get redirected to a link with a trailing slash. I added an optional catch for that.
Maybe it should be added to all matches?

If you want to do that, I can update this PR, if not we can just wait and see if that ever happens for other matches too