### PR TITLE
Generalize label handling and update to Gitlab Version 18.x

### DIFF
--- a/gitlab-scoped-labels.js
+++ b/gitlab-scoped-labels.js
@@ -1,143 +1,90 @@
 // ==UserScript==
 // @name     GitLab scoped labels (view only)
-// @version  13
+// @version  14
 // @grant    none
 // @include  https://git.octocat.lab/*
 // @license  GPL-3.0 License; https://www.gnu.org/licenses/gpl-3.0.txt
 // ==/UserScript==
 
-
-if(window.location.pathname.match(/.*\/boards/)) { // boards
-  const callback = function(mutations, observer) {
-    for(const mutation of mutations) {
-      for(const addedElement of mutation.addedNodes) {
-        const labels = document.querySelectorAll("span.gl-label");
-        for(const label of labels) {
-          if(label.innerText.includes("::")) {
-            label.classList.add("gl-label-scoped")
-            label.innerHTML = label.innerText.replace(/([^:]*)::([^:]*)/, "<a href='#' class='gl-link gl-label-link'><span class='gl-label-text'>$1</span> <span class='gl-label-text-scoped'>$2</span></a>");
-          } else if(label.parentNode.classList.contains("board-title-text")) {
-            label.classList.add("gl-label-scoped")
-          }
-        }
-      }
-    } 
+function convertToScoped(label) {
+  label.classList.add("gl-label-scoped")
+  label.firstChild.innerHTML = label.firstChild.innerText.replace(/([^:]*)::([^:]*)/, "<span class='gl-label-text'>$1</span> <span class='gl-label-text-scoped'>$2</span>");
+  if (label.classList.contains("js-no-trigger")) { // Label filter label edge case
+    return;
   }
-  const observer = new MutationObserver(callback)
-  observer.observe(document, { childList: true, subtree: true })
-} else if(window.location.pathname.match(/.*\/issues\/?$/)) { // issues list
-  const callback = function(mutations, observer) {
-    for(const mutation of mutations) {
-      for(const addedElement of mutation.addedNodes) {
-        if(addedElement.classList.contains("issue")) {
-          const labels = addedElement.querySelectorAll("span.gl-label");
-          for(const label of labels) {
-            if(label.firstChild.firstChild.innerText.includes("::")) {
-              label.classList.add("gl-label-scoped")
-              label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.*style="background-color: (#\w*)">.*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-              label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/<(.*)>([^:]*)::([^:]*)<\/span>/, "<$1>$2</span> <span class='gl-label-text-scoped'>$3</span>")
-            }
-          }
-        }
-      }
-    }
+  // Apply light/dark attribute onto the child if the css definition is needed. (Mostly in the Activity area)
+  if (label.classList.contains("gl-label-text-light")) {
+    label.firstChild.firstChild.classList.add("gl-label-text-light");
   }
-  const observer = new MutationObserver(callback)
-  observer.observe(document, { childList: true, subtree: true })
-} else if(window.location.pathname.match(/.*\/issues\/.*/)) { // issue details
-  const callback = function(mutations, observer) {
-    for(const mutation of mutations) {
-      if(mutation.target.classList.contains("issuable-show-labels")) {
-        for(const label of mutation.addedNodes) {
-          if(label.innerText.includes("::")) {
-            label.classList.add("gl-label-scoped")
-            label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.*style="background-color: (#\w*)">.*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-            label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/(.*)([^:]*)::([^:]*)(.*)/, "$1 $2</span> <span class='gl-label-text-scoped'>$3</span>$4")
-          }
-        }
-      } else if(mutation.target.classList.contains("notes")) {
-        for(const timeline of mutation.addedNodes) {
-          const labels = timeline.querySelectorAll("span.gl-label")
-          for(const label of labels) {
-            if(label.innerText.includes("::")) {
-              label.classList.add("gl-label-scoped")
-              label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;")
-              label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-              label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/<(.*)>([^:]*)::([^:]*)<\/span>/, "<$1>$2</span> <span class='gl-label-text-scoped'>$3</span>")
-            }
-          }
-        }
-      }
-    }
+  if (label.classList.contains("gl-label-text-dark")) {
+    label.firstChild.firstChild.classList.add("gl-label-text-dark");
   }
-  const observer = new MutationObserver(callback)
-  observer.observe(document, { childList: true, subtree: true })
-} else if(window.location.pathname.match(/.*\/labels/)) { // labels
-  const labels = document.querySelectorAll("span.gl-label");
-  for(const label of labels) {
-    if(label.innerText.includes("::")) {
-      label.classList.add("gl-label-scoped")
-      const color = label.innerHTML.replace(/<.*style="background-color: (#\w*)".*/, "$1")
-      label.setAttribute("style", label.getAttribute("style") + "--label-background-color: " + color + "; --label-inset-border: inset 0 0 0 2px " + color + "; color " + color + ";")
-      label.innerHTML = label.innerText.replace(/([^:]*)::([^:]*)/, "<span style='background-color: " + color + "' class='gl-label-text gl-label-text-light'>$1</span> <span class='gl-label-text-scoped'>$2</span>");
-    }
-  }
-} else if(window.location.pathname.match(/.*\/merge_requests$/)) { // merge request list
-  const labels = document.querySelectorAll("span.gl-label");
-  for(const label of labels) {
-    if(label.innerText.includes("::")) {
-      label.classList.add("gl-label-scoped")
-      const color = label.innerHTML.replace(/<.*style="background-color: (#\w*)".*/, "$1")
-      label.setAttribute("style", label.getAttribute("style") + "--label-background-color: " + color + "; --label-inset-border: inset 0 0 0 2px " + color + "; color " + color + ";")
-      label.innerHTML = label.innerText.replace(/([^:]*)::([^:]*)/, "<span style='background-color: " + color + "' class='gl-label-text gl-label-text-light'>$1</span> <span class='gl-label-text-scoped'>$2</span>");
-    }
-  }
-} else if(window.location.pathname.match(/.*\/merge_requests\/.*/)) { // merge request
-  const callback = function(mutations, observer) {
-    for(const mutation of mutations) {
-      if(mutation.target.classList.contains("issuable-show-labels")) {
-        for(const label of mutation.addedNodes) {
-          if(label.innerText.includes("::")) {
-            label.classList.add("gl-label-scoped")
-            label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.*style="background-color: (#\w*)">.*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-            label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/(.*)([^:]*)::([^:]*)(.*)/, "$1 $2</span> <span class='gl-label-text-scoped'>$3</span>$4")
-          }
-        }
-      } else if(mutation.target.classList.contains("notes")) {
-        for(const timeline of mutation.addedNodes) {
-          const labels = timeline.querySelectorAll("span.gl-label")
-          for(const label of labels) {
-            if(label.innerText.includes("::")) {
-              label.classList.add("gl-label-scoped")
-              label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;")
-              label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-              label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/<(.*)>([^:]*)::([^:]*)<\/span>/, "<$1>$2</span> <span class='gl-label-text-scoped'>$3</span>")
-            }
-          }
-        }
-      }
-    }
-  }
-  const observer = new MutationObserver(callback)
-  observer.observe(document, { childList: true, subtree: true })
-} else if(window.location.pathname.match(/.*\/milestones\/.*/)) { // milestones
-  const callback = function(mutations, observer) {
-    for(const mutation of mutations) {
-      if(mutation.target.classList.contains("tab-pane")) {
-        for(const addedElement of mutation.addedNodes) {
-          const labels = addedElement.querySelectorAll("span.gl-label");
-          for(const label of labels) {
-            if(label.innerText.includes("::")) {
-              label.classList.add("gl-label-scoped")
-              label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;")
-              label.setAttribute("style", label.getAttribute("style") + label.firstChild.innerHTML.replace(/<.* style="background-color: (#\w*)".*/, "--label-background-color: $1; --label-inset-border: inset 0 0 0 1px $1;"))
-              label.firstChild.innerHTML = label.firstChild.innerHTML.replace(/<(.*)>([^:]*)::([^:]*)<\/span>/, "<$1>$2</span> <span class='gl-label-text-scoped'>$3</span>")
-            }
-          }
-        }
-      }
-    }
-  }
-  const observer = new MutationObserver(callback)
-  observer.observe(document, { childList: true, subtree: true })
 }
+
+function extractColor(label) {
+  const rgbValueMatch = label.innerHTML.match(/.*background-color: rgb\((.*)\).*/)
+  if (rgbValueMatch) {
+    return `rgb(${rgbValueMatch[1]})`;
+  }
+  const hexValueMatch = label.innerHTML.match(/.*background-color: #([0-9a-zA-Z]*).*/)
+  if (hexValueMatch) {
+    return `#${hexValueMatch[1]}`;
+  }
+  return false;
+}
+
+function convertToScopedExtractColor(label) {
+  const color = extractColor(label);
+  if (!color) {
+    return;
+  }
+  label.setAttribute("style", "--label-background-color: " + color + "; --label-inset-border: inset 0 0 0 2px " + color + ";")
+  label.firstChild.classList.remove("gfm");
+  label.firstChild.classList.remove("gfm-label");
+  label.firstChild.classList.add("gl-label-link-underline");
+  label.firstChild.classList.add("has-tooltip");
+  if (label.classList.contains("js-no-trigger")) { // Label filter label edge case
+    return;
+  }
+  // Some labels still store text light/dark attribute on the child. So we move to the parent so that we don't lose it.
+  if (label.firstChild.firstChild.classList.contains("gl-label-text-light")) {
+    label.classList.add("gl-label-text-light");
+  }
+  if (label.firstChild.firstChild.classList.contains("gl-label-text-dark")) {
+    label.classList.add("gl-label-text-dark");
+  }
+}
+
+const callback = function(mutations, observer) {
+  for(const mutation of mutations) {
+    if (mutation.type === "attributes"
+        && mutation.attributeName === "class") {
+      /* Watch class attribute mutations to support labels in filter dropdown. But Gitlab does some javascript stuff
+       * that messes with our first pass.
+       */
+      if (mutation.target.classList.contains("gl-filtered-search-token-segment")) {
+        const labels = mutation.target.querySelectorAll("span.gl-label");
+        for(const label of labels) {
+          if(label.firstChild.firstChild.innerText.includes("::")) {
+            convertToScoped(label);
+          }
+        }
+      }
+      else if (mutation.target.classList.contains("gl-label")
+          && mutation.target.classList.contains("js-no-trigger")
+          && !mutation.target.classList.contains("gl-label-scoped")) {
+        // Brute force solution to make sure that Gitlab does not stomp on us.
+        mutation.target.classList.add("gl-label-scoped");
+      }
+    }
+    const labels = document.querySelectorAll("span.gl-label");
+    for(const label of labels) {
+      if(label.innerText.includes("::")) {
+        convertToScopedExtractColor(label);
+        convertToScoped(label);
+      }
+    }
+  }
+}
+const observer = new MutationObserver(callback);
+observer.observe(document, { childList: true, subtree: true, attributes: true });


### PR DESCRIPTION
Uses a more general case for label scoping across different Gitlab pages. The UI seems to be more general and supports this behavior. This should make maintaining this script easier.

I don't know if this is the most performant solution, but it works fine with my self hosted system that isn't exactly bleeding fast anyways.

I also made sure to support the labels that show in the filter bar. I had some issues fighting with Gitlab's Javascript. And I understand that there might be a better solution, but what I have seems to work.

Tested on Gitlab version: `18.0.1`